### PR TITLE
Refactor to /api-specification-versions/{apiSpecificationVersionId} endpoints

### DIFF
--- a/docs/learn/agreements/adding-a-trust-framework.md
+++ b/docs/learn/agreements/adding-a-trust-framework.md
@@ -18,7 +18,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="7"
-    POST https://api.zorgapis.nl/v1beta1/trust-frameworks HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/trust-frameworks HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/agreements/snippets/add-trust-framework_request.json"
@@ -54,7 +54,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="7"
-    POST https://api.zorgapis.nl/v1beta1/trust-framework-versions HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/trust-framework-versions HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/agreements/snippets/add-trust-framework-version_request.json"
@@ -100,7 +100,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="5"
-    PATCH https://api.zorgapis.nl/v1beta1/trust-frameworks/3d443c34-24a4-4640-bfe5-822627af76e2 HTTP/1.1
+    PATCH https://api.zorgapis.nl/v1beta2/trust-frameworks/3d443c34-24a4-4640-bfe5-822627af76e2 HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/agreements/snippets/set-trust-framework-main-version_request.json"
@@ -128,7 +128,7 @@ erDiagram
 === "Request"
 
     ```json
-    GET https://api.zorgapis.nl/v1beta1/trust-frameworks HTTP/1.1
+    GET https://api.zorgapis.nl/v1beta2/trust-frameworks HTTP/1.1
     ```
 
 === "Response"
@@ -158,7 +158,7 @@ List all versions for the trust framework with id `#!js "3b49f2e6-fd5c-48a8-a59c
 === "Request"
 
     ```json
-    GET https://api.zorgapis.nl/v1beta1/trust-framework-versions
+    GET https://api.zorgapis.nl/v1beta2/trust-framework-versions
         ?filter=eq(trustFrameworkId,"3b49f2e6-fd5c-48a8-a59c-5fcbed78e5ae") HTTP/1.1
     ```
 

--- a/docs/learn/apis/adding-an-api-specification.md
+++ b/docs/learn/apis/adding-an-api-specification.md
@@ -362,3 +362,59 @@ available versions of a trust framework.
     or fork our [Postman Collection](
     https://www.postman.com/zorgapis/zorgapis/collection/6oerml3/zorgapis-api){: target="_blank" }
     and explore our API.
+
+## Get API specifications
+
+=== "Request"
+
+    ```json
+    GET https://api.zorgapis.nl/v1beta2/api-specifications HTTP/1.1
+    ```
+
+=== "Response"
+
+    ```json hl_lines="6 15"
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    --8<-- "learn/apis/snippets/get-api-specifications_response.json"
+    ```
+
+    1.  The UUID of the [API specification](#add-api-specification).
+    2.  The UUID of the [main version](#set-api-specification-main-version-request).
+
+!!! note
+
+    To learn more, view the [API reference](
+    https://oas.zorgapis.nl/#tag/api-specifications/operation/listApiSpecifications){: target="_blank" }
+    or fork our [Postman Collection](
+    https://www.postman.com/zorgapis/zorgapis/collection/6oerml3/zorgapis-api){: target="_blank" }
+    and explore our API.
+
+## Get API specification versions
+
+List all versions for the API specification with id `#!js "fe30bf05-de07-4556-9b17-1f82d62fe45f"`:
+
+=== "Request"
+
+    ```json
+    GET https://api.zorgapis.nl/v1beta2/api-specification-versions
+        ?filter=eq(apiSpecificationId,"fe30bf05-de07-4556-9b17-1f82d62fe45f") HTTP/1.1
+    ```
+
+=== "Response"
+
+    ```json hl_lines="9"
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    --8<-- "learn/apis/snippets/get-api-specification-versions_response.json"
+    ```
+
+!!! note
+
+    To learn more, view the [API reference](
+    https://oas.zorgapis.nl/#tag/api-specification-versions/operation/listApiSpecificationVersions){: target="_blank" }
+    or fork our [Postman Collection](
+    https://www.postman.com/zorgapis/zorgapis/collection/6oerml3/zorgapis-api){: target="_blank" }
+    and explore our API.

--- a/docs/learn/apis/adding-an-api-specification.md
+++ b/docs/learn/apis/adding-an-api-specification.md
@@ -20,7 +20,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="7"
-    POST https://api.zorgapis.nl/v1beta1/api-specifications HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/api-specifications HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/apis/snippets/add-api-specification_request.json"
@@ -58,7 +58,7 @@ erDiagram
 === "Request"
 
     ```json
-    POST https://api.zorgapis.nl/v1beta1/api-specification-versions HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/api-specification-versions HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/apis/snippets/add-api-specification-version_request.json"
@@ -219,7 +219,7 @@ used with our
 === "Request"
 
     ```json
-    POST https://api.zorgapis.nl/v1beta1/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/declarations-of-conformity HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/declarations-of-conformity HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/apis/snippets/add-declaration-of-conformity_request.json"
@@ -253,7 +253,7 @@ used with our
 === "Request"
 
     ```json hl_lines="5"
-    PATCH https://api.zorgapis.nl/v1beta1/api-specifications/fe30bf05-de07-4556-9b17-1f82d62fe45f HTTP/1.1
+    PATCH https://api.zorgapis.nl/v1beta2/api-specifications/fe30bf05-de07-4556-9b17-1f82d62fe45f HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/apis/snippets/set-api-specification-main-version_request.json"
@@ -285,7 +285,7 @@ listing all available versions of a communication standard.
 === "Request"
 
     ```json
-    PUT https://api.zorgapis.nl/v1beta1/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/communication-standard-versions/8ae84d7f-73e7-4f08-b839-c73c97128ada HTTP/1.1
+    PUT https://api.zorgapis.nl/v1beta2/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/communication-standard-versions/8ae84d7f-73e7-4f08-b839-c73c97128ada HTTP/1.1
     ```
 
 === "Response"
@@ -314,7 +314,7 @@ listing all available versions of an information standard.
 === "Request"
 
     ```json
-    PUT https://api.zorgapis.nl/v1beta1/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/information-standard-versions/20685da1-0e1d-40b9-a0f6-5a89c444f48c HTTP/1.1
+    PUT https://api.zorgapis.nl/v1beta2/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/information-standard-versions/20685da1-0e1d-40b9-a0f6-5a89c444f48c HTTP/1.1
     ```
 
 === "Response"
@@ -343,7 +343,7 @@ available versions of a trust framework.
 === "Request"
 
     ```json
-    PUT https://api.zorgapis.nl/v1beta1/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/trust-framework-versions/78ca8495-a4f4-4b41-b97b-c912c2e96450 HTTP/1.1
+    PUT https://api.zorgapis.nl/v1beta2/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/trust-framework-versions/78ca8495-a4f4-4b41-b97b-c912c2e96450 HTTP/1.1
     ```
 
 === "Response"

--- a/docs/learn/apis/adding-an-api-specification.md
+++ b/docs/learn/apis/adding-an-api-specification.md
@@ -58,14 +58,15 @@ erDiagram
 === "Request"
 
     ```json
-    POST https://api.zorgapis.nl/v1beta1/api-specifications/fe30bf05-de07-4556-9b17-1f82d62fe45f/versions HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta1/api-specification-versions HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/apis/snippets/add-api-specification-version_request.json"
     ```
 
     1.  The name of the API specification version, must be **unique** for this API specification.
-    2.  The date and time (formatted as per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601){: target="_blank" }) at
+    2.  The UUID of the [API specification](#add-api-specification) to which this version belongs.
+    3.  The date and time (formatted as per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601){: target="_blank" }) at
         which the API specification version was published. In other words, the date and time at which this version was
         first made available by the [organization](../organizations/adding-an-organization.md#add-organization) that
         maintains the API specification.
@@ -73,13 +74,13 @@ erDiagram
         **Note**: `publishTime` is **not** to be used for the date and time at which this version is published in the
         API Library for Dutch Healthcare. This value is set automatically by the API server upon creation of the item
         and can be accessed via read-only property `createTime`.
-    3.  The [SemVer](https://semver.org/){: target="_blank" } version information. Additional properties for pre-release
+    4.  The [SemVer](https://semver.org/){: target="_blank" } version information. Additional properties for pre-release
         (`#!js "preRelease"`) and build metadata (`#!js "build"`) are available.
-    4.  The URL type, for example, `#!js "OPENAPI_SPECIFICATION"`.
+    5.  The URL type, for example, `#!js "OPENAPI_SPECIFICATION"`.
 
 === "Response"
 
-    ```json hl_lines="5 17 22"
+    ```json hl_lines="5 9-12 22 27"
     HTTP/1.1 201 Created
     Content-Type: application/json
 
@@ -96,7 +97,7 @@ erDiagram
 !!! note
 
     To learn more, view the [API reference](
-    https://oas.zorgapis.nl/#tag/api-specifications.versions/operation/addApiSpecificationVersion){: target="_blank" }
+    https://oas.zorgapis.nl/#tag/api-specification-versions/operation/addApiSpecificationVersion){: target="_blank" }
     or fork our [Postman Collection](
     https://www.postman.com/zorgapis/zorgapis/collection/6oerml3/zorgapis-api){: target="_blank" }
     and explore our API.
@@ -218,7 +219,7 @@ used with our
 === "Request"
 
     ```json
-    POST https://api.zorgapis.nl/v1beta1/api-specifications/fe30bf05-de07-4556-9b17-1f82d62fe45f/versions/15261fd0-b292-45d9-b6b1-266cc922fb50/declarations-of-conformity HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta1/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/declarations-of-conformity HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/apis/snippets/add-declaration-of-conformity_request.json"
@@ -242,7 +243,7 @@ used with our
 !!! note
 
     To learn more, view the [API reference](
-    https://oas.zorgapis.nl/#tag/api-specifications.versions.declarations-of-conformity/operation/addApiSpecificationVersionDeclarationOfConformity){: target="_blank" }
+    https://oas.zorgapis.nl/#tag/api-specification-versions.declarations-of-conformity/operation/addApiSpecificationVersionDeclarationOfConformity){: target="_blank" }
     or fork our [Postman Collection](
     https://www.postman.com/zorgapis/zorgapis/collection/6oerml3/zorgapis-api){: target="_blank" }
     and explore our API.
@@ -284,7 +285,7 @@ listing all available versions of a communication standard.
 === "Request"
 
     ```json
-    PUT https://api.zorgapis.nl/v1beta1/api-specifications/fe30bf05-de07-4556-9b17-1f82d62fe45f/versions/15261fd0-b292-45d9-b6b1-266cc922fb50/communication-standard-versions/8ae84d7f-73e7-4f08-b839-c73c97128ada HTTP/1.1
+    PUT https://api.zorgapis.nl/v1beta1/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/communication-standard-versions/8ae84d7f-73e7-4f08-b839-c73c97128ada HTTP/1.1
     ```
 
 === "Response"
@@ -299,7 +300,7 @@ listing all available versions of a communication standard.
 !!! note
 
     To learn more, view the [API reference](
-    https://oas.zorgapis.nl/#tag/api-specifications.versions.communication-standard-versions/operation/setApiSpecificationVersionCommunicationStandardVersion){: target="_blank" }
+    https://oas.zorgapis.nl/#tag/api-specification-versions.communication-standard-versions/operation/setApiSpecificationVersionCommunicationStandardVersion){: target="_blank" }
     or fork our [Postman Collection](
     https://www.postman.com/zorgapis/zorgapis/collection/6oerml3/zorgapis-api){: target="_blank" }
     and explore our API.
@@ -313,7 +314,7 @@ listing all available versions of an information standard.
 === "Request"
 
     ```json
-    PUT https://api.zorgapis.nl/v1beta1/api-specifications/fe30bf05-de07-4556-9b17-1f82d62fe45f/versions/15261fd0-b292-45d9-b6b1-266cc922fb50/information-standard-versions/20685da1-0e1d-40b9-a0f6-5a89c444f48c HTTP/1.1
+    PUT https://api.zorgapis.nl/v1beta1/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/information-standard-versions/20685da1-0e1d-40b9-a0f6-5a89c444f48c HTTP/1.1
     ```
 
 === "Response"
@@ -328,7 +329,7 @@ listing all available versions of an information standard.
 !!! note
 
     To learn more, view the [API reference](
-    https://oas.zorgapis.nl/#tag/api-specifications.versions.information-standard-versions/operation/setApiSpecificationVersionInformationStandardVersion){: target="_blank" }
+    https://oas.zorgapis.nl/#tag/api-specification-versions.information-standard-versions/operation/setApiSpecificationVersionInformationStandardVersion){: target="_blank" }
     or fork our [Postman Collection](
     https://www.postman.com/zorgapis/zorgapis/collection/6oerml3/zorgapis-api){: target="_blank" }
     and explore our API.
@@ -342,7 +343,7 @@ available versions of a trust framework.
 === "Request"
 
     ```json
-    PUT https://api.zorgapis.nl/v1beta1/api-specifications/fe30bf05-de07-4556-9b17-1f82d62fe45f/versions/15261fd0-b292-45d9-b6b1-266cc922fb50/trust-framework-versions/78ca8495-a4f4-4b41-b97b-c912c2e96450 HTTP/1.1
+    PUT https://api.zorgapis.nl/v1beta1/api-specification-versions/15261fd0-b292-45d9-b6b1-266cc922fb50/trust-framework-versions/78ca8495-a4f4-4b41-b97b-c912c2e96450 HTTP/1.1
     ```
 
 === "Response"
@@ -357,7 +358,7 @@ available versions of a trust framework.
 !!! note
 
     To learn more, view the [API reference](
-    https://oas.zorgapis.nl/#tag/api-specifications.versions.trust-framework-versions/operation/setApiSpecificationVersionTrustFrameworkVersion){: target="_blank" }
+    https://oas.zorgapis.nl/#tag/api-specification-versions.trust-framework-versions/operation/setApiSpecificationVersionTrustFrameworkVersion){: target="_blank" }
     or fork our [Postman Collection](
     https://www.postman.com/zorgapis/zorgapis/collection/6oerml3/zorgapis-api){: target="_blank" }
     and explore our API.

--- a/docs/learn/apis/getting-api-requirements.md
+++ b/docs/learn/apis/getting-api-requirements.md
@@ -18,7 +18,7 @@ List all must-have requirements for API specifications with the REST architectur
 === "Request"
 
     ```json
-    GET https://api.zorgapis.nl/v1beta1/api-requirements-versions/1.2.0/api-requirements
+    GET https://api.zorgapis.nl/v1beta2/api-requirements-versions/1.2.0/api-requirements
         ?filter=and(
             eq(requirementLevel,"MUST"), // (1)!
             any(perspectiveTypes,eq($it,"API_SPECIFICATION")), // (2)!

--- a/docs/learn/apis/snippets/add-api-specification-version_request.json
+++ b/docs/learn/apis/snippets/add-api-specification-version_request.json
@@ -1,8 +1,9 @@
 ﻿{
   "name": "2.0", // (1)!
   "description": "Verzamelen Huisartsgegevens 2.0",
-  "publishTime": "2020-09-02T00:00:00.000Z", // (2)!
-  "semVer": { // (3)!
+  "apiSpecificationId": "fe30bf05-de07-4556-9b17-1f82d62fe45f", // (2)!
+  "publishTime": "2020-09-02T00:00:00.000Z", // (3)!
+  "semVer": { // (4)!
     "major": 2,
     "minor": 0,
     "patch": 0
@@ -10,7 +11,7 @@
   "lifecycleState": "PUBLISHED",
   "urls": [
     {
-      "type": "FUNCTIONAL_DESIGN", // (4)!
+      "type": "FUNCTIONAL_DESIGN", // (5)!
       "url": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2020.01/OntwerpHuisartsgegevens"
     },
     {

--- a/docs/learn/apis/snippets/add-api-specification-version_response.json
+++ b/docs/learn/apis/snippets/add-api-specification-version_response.json
@@ -2,6 +2,11 @@
   "id": "15261fd0-b292-45d9-b6b1-266cc922fb50", // (1)!
   "name": "2.0",
   "description": "Verzamelen Huisartsgegevens 2.0",
+  "apiSpecificationId": "fe30bf05-de07-4556-9b17-1f82d62fe45f",
+  "apiSpecification": {
+    "id": "fe30bf05-de07-4556-9b17-1f82d62fe45f",
+    "name": "Verzamelen Huisartsgegevens"
+  },
   "publishTime": "2020-09-02T00:00:00.000Z",
   "semVer": {
     "major": 2,

--- a/docs/learn/apis/snippets/get-api-specification-versions_response.json
+++ b/docs/learn/apis/snippets/get-api-specification-versions_response.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "15261fd0-b292-45d9-b6b1-266cc922fb50",
+    "name": "2.0",
+    "description": "Verzamelen Huisartsgegevens 2.0",
+    "apiSpecificationId": "fe30bf05-de07-4556-9b17-1f82d62fe45f",
+    "apiSpecification": {
+      "id": "fe30bf05-de07-4556-9b17-1f82d62fe45f",
+      "name": "Verzamelen Huisartsgegevens"
+    },
+    "publishTime": "2020-09-02T00:00:00.000Z",
+    "semVer": {
+      "major": 2,
+      "minor": 0,
+      "patch": 0
+    },
+    "lifecycleState": "PUBLISHED",
+    "urls": [
+      {
+        "id": "37bfbf71-570c-45c1-9fbf-7e5f63db61b8",
+        "type": "FUNCTIONAL_DESIGN",
+        "url": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2020.01/OntwerpHuisartsgegevens"
+      },
+      {
+        "id": "8a87c023-aabb-454f-8e1a-3443a13f11e2",
+        "type": "TECHNICAL_DESIGN",
+        "url": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2020.01/FHIR_GP_Data"
+      }
+    ],
+    "lastDeclarationOfConformity": {
+      "id": "188c9c2c-ea9e-48fa-8423-5e8e2f60161c",
+      "requirementsVersion": "1.2.0",
+      "rankingLevel": "OPEN_API",
+      "rankings": {
+        "OPEN_API": {
+          "score": 27,
+          "maximumScore": 31
+        },
+        "TECHNICALLY_STANDARDIZED_API": {
+          "score": 6,
+          "maximumScore": 11
+        },
+        "FULLY_STANDARDIZED_API": {
+          "score": 2,
+          "maximumScore": 6
+        }
+      }
+    }
+  },
+  ...
+]

--- a/docs/learn/apis/snippets/get-api-specifications_response.json
+++ b/docs/learn/apis/snippets/get-api-specifications_response.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "fe30bf05-de07-4556-9b17-1f82d62fe45f", // (1)!
+    "name": "Verzamelen Huisartsgegevens",
+    "description": "Het verzamelen van huisartsgegevens: je medische dossier bij je huisarts.",
+    "organizationId": "4a7c2c17-6514-46f8-aa05-6a22fb18b4ad",
+    "organization": {
+      "id": "4a7c2c17-6514-46f8-aa05-6a22fb18b4ad",
+      "name": "Nictiz"
+    },
+    "architecturalStyle": "REST",
+    "mainVersionId": "15261fd0-b292-45d9-b6b1-266cc922fb50", // (2)!
+    "mainVersion": {
+      "id": "15261fd0-b292-45d9-b6b1-266cc922fb50",
+      "name": "2.0",
+      "description": "Verzamelen Huisartsgegevens 2.0",
+      "publishTime": "2020-09-02T00:00:00.000Z",
+      "semVer": {
+        "major": 2,
+        "minor": 0,
+        "patch": 0
+      },
+      "lifecycleState": "PUBLISHED",
+      "urls": [
+        {
+          "id": "37bfbf71-570c-45c1-9fbf-7e5f63db61b8",
+          "type": "FUNCTIONAL_DESIGN",
+          "url": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2020.01/OntwerpHuisartsgegevens"
+        },
+        {
+          "id": "8a87c023-aabb-454f-8e1a-3443a13f11e2",
+          "type": "TECHNICAL_DESIGN",
+          "url": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2020.01/FHIR_GP_Data"
+        }
+      ],
+      "lastDeclarationOfConformity": {
+        "id": "188c9c2c-ea9e-48fa-8423-5e8e2f60161c",
+        "requirementsVersion": "1.2.0",
+        "rankingLevel": "OPEN_API",
+        "rankings": {
+          "OPEN_API": {
+            "score": 27,
+            "maximumScore": 31
+          },
+          "TECHNICALLY_STANDARDIZED_API": {
+            "score": 6,
+            "maximumScore": 11
+          },
+          "FULLY_STANDARDIZED_API": {
+            "score": 2,
+            "maximumScore": 6
+          }
+        }
+      }
+    }
+  },
+  ...
+]

--- a/docs/learn/organizations/accepting-an-invitation-to-join-an-organization.md
+++ b/docs/learn/organizations/accepting-an-invitation-to-join-an-organization.md
@@ -22,7 +22,7 @@ erDiagram
 === "Request"
 
     ```json
-    GET https://api.zorgapis.nl/v1beta1/users/me/invitations?filter=eq(status,"PENDING") HTTP/1.1
+    GET https://api.zorgapis.nl/v1beta2/users/me/invitations?filter=eq(status,"PENDING") HTTP/1.1
     ```
 
 === "Response"
@@ -47,7 +47,7 @@ erDiagram
 === "Request"
 
     ```json
-    POST https://api.zorgapis.nl/v1beta1/users/me/invitations/88411780-1d25-4bc3-86a5-f2f901d9a900:accept HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/users/me/invitations/88411780-1d25-4bc3-86a5-f2f901d9a900:accept HTTP/1.1
     ```
 
 === "Response"

--- a/docs/learn/organizations/adding-an-organization.md
+++ b/docs/learn/organizations/adding-an-organization.md
@@ -14,7 +14,7 @@ https://www.zorgapis.nl/){: target="_blank" } via our API.
 === "Request"
 
     ```json
-    POST https://api.zorgapis.nl/v1beta1/organizations HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/organizations HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/organizations/snippets/add-organization_request.json"

--- a/docs/learn/organizations/inviting-a-user-to-an-organization.md
+++ b/docs/learn/organizations/inviting-a-user-to-an-organization.md
@@ -22,7 +22,7 @@ erDiagram
 === "Request"
 
     ```json
-    POST https://api.zorgapis.nl/v1beta1/organizations/4a7c2c17-6514-46f8-aa05-6a22fb18b4ad/invitations HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/organizations/4a7c2c17-6514-46f8-aa05-6a22fb18b4ad/invitations HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/organizations/snippets/add-invitation_request.json"

--- a/docs/learn/standards/adding-a-communication-standard.md
+++ b/docs/learn/standards/adding-a-communication-standard.md
@@ -18,7 +18,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="7"
-    POST https://api.zorgapis.nl/v1beta1/communication-standards HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/communication-standards HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/standards/snippets/add-communication-standard_request.json"
@@ -54,7 +54,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="7"
-    POST https://api.zorgapis.nl/v1beta1/communication-standard-versions HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/communication-standard-versions HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/standards/snippets/add-communication-standard-version_request.json"
@@ -100,7 +100,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="5"
-    PATCH https://api.zorgapis.nl/v1beta1/communication-standards/05d8de10-1932-4e7f-badf-655c1a82fcc3 HTTP/1.1
+    PATCH https://api.zorgapis.nl/v1beta2/communication-standards/05d8de10-1932-4e7f-badf-655c1a82fcc3 HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/standards/snippets/set-communication-standard-main-version_request.json"
@@ -128,7 +128,7 @@ erDiagram
 === "Request"
 
     ```json
-    GET https://api.zorgapis.nl/v1beta1/communication-standards HTTP/1.1
+    GET https://api.zorgapis.nl/v1beta2/communication-standards HTTP/1.1
     ```
 
 === "Response"
@@ -158,7 +158,7 @@ List all versions for the communication standard with id `#!js "05d8de10-1932-4e
 === "Request"
 
     ```json
-    GET https://api.zorgapis.nl/v1beta1/communication-standard-versions
+    GET https://api.zorgapis.nl/v1beta2/communication-standard-versions
         ?filter=eq(communicationStandardId,"05d8de10-1932-4e7f-badf-655c1a82fcc3") HTTP/1.1
     ```
 

--- a/docs/learn/standards/adding-an-information-standard.md
+++ b/docs/learn/standards/adding-an-information-standard.md
@@ -18,7 +18,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="7"
-    POST https://api.zorgapis.nl/v1beta1/information-standards HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/information-standards HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/standards/snippets/add-information-standard_request.json"
@@ -54,7 +54,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="7"
-    POST https://api.zorgapis.nl/v1beta1/information-standard-versions HTTP/1.1
+    POST https://api.zorgapis.nl/v1beta2/information-standard-versions HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/standards/snippets/add-information-standard-version_request.json"
@@ -100,7 +100,7 @@ erDiagram
 === "Request"
 
     ```json hl_lines="5"
-    PATCH https://api.zorgapis.nl/v1beta1/information-standards/7bc962b1-601d-4759-9a87-68953e7b75e2 HTTP/1.1
+    PATCH https://api.zorgapis.nl/v1beta2/information-standards/7bc962b1-601d-4759-9a87-68953e7b75e2 HTTP/1.1
     Content-Type: application/json
 
     --8<-- "learn/standards/snippets/set-information-standard-main-version_request.json"
@@ -132,7 +132,7 @@ listing all available versions of a communication standard.
 === "Request"
 
     ```json
-    PUT https://api.zorgapis.nl/v1beta1/information-standard-versions/20685da1-0e1d-40b9-a0f6-5a89c444f48c/communication-standard-versions/8ae84d7f-73e7-4f08-b839-c73c97128ada HTTP/1.1
+    PUT https://api.zorgapis.nl/v1beta2/information-standard-versions/20685da1-0e1d-40b9-a0f6-5a89c444f48c/communication-standard-versions/8ae84d7f-73e7-4f08-b839-c73c97128ada HTTP/1.1
     ```
 
 === "Response"
@@ -161,7 +161,7 @@ available versions of a trust framework.
 === "Request"
 
     ```json
-    PUT https://api.zorgapis.nl/v1beta1/information-standard-versions/20685da1-0e1d-40b9-a0f6-5a89c444f48c/trust-framework-versions/78ca8495-a4f4-4b41-b97b-c912c2e96450 HTTP/1.1
+    PUT https://api.zorgapis.nl/v1beta2/information-standard-versions/20685da1-0e1d-40b9-a0f6-5a89c444f48c/trust-framework-versions/78ca8495-a4f4-4b41-b97b-c912c2e96450 HTTP/1.1
     ```
 
 === "Response"
@@ -186,7 +186,7 @@ available versions of a trust framework.
 === "Request"
 
     ```json
-    GET https://api.zorgapis.nl/v1beta1/information-standards HTTP/1.1
+    GET https://api.zorgapis.nl/v1beta2/information-standards HTTP/1.1
     ```
 
 === "Response"
@@ -216,7 +216,7 @@ List all versions for the information standard with id `#!js "7bc962b1-601d-4759
 === "Request"
 
     ```json
-    GET https://api.zorgapis.nl/v1beta1/information-standard-versions
+    GET https://api.zorgapis.nl/v1beta2/information-standard-versions
         ?filter=eq(informationStandardId,"7bc962b1-601d-4759-9a87-68953e7b75e2") HTTP/1.1
     ```
 


### PR DESCRIPTION
Refactors /api-specifications/{apiSpecificationId}/versions endpoints to
/api-specification-versions/{apiSpecificationVersionId} endpoints to allow for querying versions without needing the
apiSpecificationId, which brings it in line with other endpoints, like /information-standard-versions and
/trust-framework-versions. As this is a breaking change, the version has been updated to v1beta2.